### PR TITLE
Fix list unmarshal bug

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,16 +63,15 @@ func (c *Client) ListRecords(tableName string, recordsHolder interface{}, listPa
 		listParameters := listParams[len(listParams)-1]
 		endpoint = fmt.Sprintf("%s%s", endpoint, listParameters.URLEncode())
 	}
-	tempRecordsHolder := reflect.New(reflect.TypeOf(recordsHolder).Elem()).Interface()
 	offsetHash := ""
 	// We pass tempRecordsHolder here as a perf optimization so that we do not need to re-derive
 	// the tempRecord for each request using reflection, but can instead reuse a single one. Since
 	// tempRecordsHolder is always a slice, it's contents will be entirely replaced with each
 	// subsequent unmarshalling.
-	return c.recursivelyListRecordsAtOffset(endpoint, offsetHash, tempRecordsHolder, recordsHolder)
+	return c.recursivelyListRecordsAtOffset(endpoint, offsetHash, recordsHolder)
 }
 
-func (c *Client) recursivelyListRecordsAtOffset(endpoint string, offsetHash string, tempRecordsHolder, finalRecordsHolder interface{}) error {
+func (c *Client) recursivelyListRecordsAtOffset(endpoint string, offsetHash string, finalRecordsHolder interface{}) error {
 	finalEndpoint := fmt.Sprintf("%s&offset=%s", endpoint, offsetHash)
 	rawBody, err := c.request("GET", finalEndpoint, nil)
 	if err != nil {
@@ -98,6 +97,7 @@ func (c *Client) recursivelyListRecordsAtOffset(endpoint string, offsetHash stri
 		return err
 	}
 
+	tempRecordsHolder := reflect.New(reflect.TypeOf(finalRecordsHolder).Elem()).Interface()
 	// Unmarshall once more into the supplied tempRecordsHolder, an array of records
 	if err = json.Unmarshal(jsonRecords, tempRecordsHolder); err != nil {
 		return err
@@ -106,10 +106,11 @@ func (c *Client) recursivelyListRecordsAtOffset(endpoint string, offsetHash stri
 	// Append the records returned from this request to the final list of records using reflection
 	finalRecordsHolderVal := reflect.ValueOf(finalRecordsHolder).Elem()
 	tempRecordsHolderVal := reflect.ValueOf(tempRecordsHolder).Elem()
+
 	finalRecordsHolderVal.Set(reflect.AppendSlice(finalRecordsHolderVal, tempRecordsHolderVal))
 
 	if rl.Offset != "" {
-		return c.recursivelyListRecordsAtOffset(endpoint, rl.Offset, tempRecordsHolder, finalRecordsHolder)
+		return c.recursivelyListRecordsAtOffset(endpoint, rl.Offset, finalRecordsHolder)
 	}
 	return nil
 }
@@ -377,3 +378,4 @@ func checkStatusCodeForError(statusCode int, rawBody []byte) error {
 	}
 	return nil
 }
+


### PR DESCRIPTION
I've discovered a bug in list where some values from previous rows lingered, ie:


| Row ID | Col A | Col B|
| --- | --- | --- |
| ROW 1 |  Val A1 |  Val B1 |
| ROW 2 | | Val B2  |

So list returned Val A1 for both row 1 and row 2.

I suspect the json output from the airtable api omits empty strings, and with the key missing the reused `tempsRecordsHolder` is not being updated.

To avoid that, I moved its initialisation inside the recursive function `recursivelyListRecordsAtOffset`.
That fixed my problems.

Edit: I've just read the comments above the code I've modified again and it made me doubt myself. Have to give this a second thought.

Edit2: I've just ran a second round of tests and the bug is definitely there and this patch definitely fixes it. Will try to come up with a repro.